### PR TITLE
dependencies: remove upper bound for text

### DIFF
--- a/pandoc-csv2table.cabal
+++ b/pandoc-csv2table.cabal
@@ -24,7 +24,7 @@ Source-repository     head
 Library
   Build-Depends:      base >=4.6 && <5,
                       csv >= 0.1.2,
-                      text >= 0.11 && < 1.3,
+                      text >= 0.11,
                       pandoc >= 1.13.0.0,
                       pandoc-types >= 1.12.0.0
   Hs-Source-Dirs:     src


### PR DESCRIPTION
This builds and works fine with text 2.0.
